### PR TITLE
feat: update datepicker

### DIFF
--- a/components/nativewindui/DatePicker/DatePicker.android.tsx
+++ b/components/nativewindui/DatePicker/DatePicker.android.tsx
@@ -3,10 +3,18 @@ import * as React from 'react';
 import { Pressable, View } from 'react-native';
 
 import { Text } from '~/components/nativewindui/Text';
+import { cn } from '~/lib/cn';
 
 export function DatePicker(
   props: React.ComponentProps<typeof DateTimePicker> & {
     mode: 'date' | 'time' | 'datetime';
+  } & {
+    materialDateClassName?: string;
+    materialDateLabel?: string;
+    materialDateLabelClassName?: string;
+    materialTimeClassName?: string;
+    materialTimeLabel?: string;
+    materialTimeLabelClassName?: string;
   }
 ) {
   const show = (currentMode: 'time' | 'date') => () => {
@@ -22,37 +30,39 @@ export function DatePicker(
   return (
     <View className="flex-row gap-2.5">
       {props.mode.includes('date') && (
-        <View className="relative pt-1.5">
+        <View className={cn('relative pt-1.5', props.materialDateClassName)}>
           <Pressable
             onPress={show('date')}
-            className="rounded-md border border-border px-5 py-3 active:opacity-80">
-            <Text variant="subhead">
+            className="border-foreground/30 rounded border py-3 pl-2.5 active:opacity-80">
+            <Text className="py-px">
               {new Intl.DateTimeFormat('en-US', {
                 dateStyle: 'medium',
               }).format(props.value)}
             </Text>
           </Pressable>
-          <View className="absolute left-2 top-0 bg-card px-1">
+          <View
+            className={cn('absolute left-2 top-0 bg-card px-1', props.materialDateLabelClassName)}>
             <Text variant="caption2" className="text-[10px] opacity-60">
-              Date
+              {props.materialDateLabel ?? 'Date'}
             </Text>
           </View>
         </View>
       )}
       {props.mode.includes('time') && (
-        <View className="relative pt-1.5">
+        <View className={cn('relative pt-1.5', props.materialTimeClassName)}>
           <Pressable
             onPress={show('time')}
-            className="rounded-md border border-border px-5 py-3 active:opacity-80">
-            <Text variant="subhead">
+            className="border-foreground/30 rounded border py-3 pl-2.5 active:opacity-80">
+            <Text className="py-px">
               {new Intl.DateTimeFormat('en-US', {
                 timeStyle: 'short',
               }).format(props.value)}
             </Text>
           </Pressable>
-          <View className="absolute left-2 top-0 bg-card px-1">
+          <View
+            className={cn('absolute left-2 top-0 bg-card px-1', props.materialTimeLabelClassName)}>
             <Text variant="caption2" className="text-[10px] opacity-60">
-              Time
+              {props.materialTimeLabel ?? 'Time'}
             </Text>
           </View>
         </View>

--- a/components/nativewindui/DatePicker/DatePicker.tsx
+++ b/components/nativewindui/DatePicker/DatePicker.tsx
@@ -1,10 +1,23 @@
 import DateTimePicker from '@react-native-community/datetimepicker';
 import * as React from 'react';
 
-export function DatePicker(
-  props: React.ComponentProps<typeof DateTimePicker> & {
-    mode: 'date' | 'time' | 'datetime';
-  }
-) {
+export function DatePicker({
+  materialDateClassName: _materialDateClassName,
+  materialDateLabel: _materialDateLabel,
+  materialDateLabelClassName: _materialDateLabelClassName,
+  materialTimeClassName: _materialTimeClassName,
+  materialTimeLabel: _materialTimeLabel,
+  materialTimeLabelClassName: _materialTimeLabelClassName,
+  ...props
+}: React.ComponentProps<typeof DateTimePicker> & {
+  mode: 'date' | 'time' | 'datetime';
+} & {
+  materialDateClassName?: string;
+  materialDateLabel?: string;
+  materialDateLabelClassName?: string;
+  materialTimeClassName?: string;
+  materialTimeLabel?: string;
+  materialTimeLabelClassName?: string;
+}) {
   return <DateTimePicker {...props} />;
 }


### PR DESCRIPTION
# Requires update to CES?
Yes

## Description
- Updates the styling for sizing to match the TextField component
- Adds material props to allow for more customization
- Adds the material prop types to the iOS component for proper type checking. Any more props and there should be a `types.ts` file. I think this is the limit to what is manageable.

#### Before

<img width="395" alt="Screenshot 2024-07-27 at 11 45 08 AM" src="https://github.com/user-attachments/assets/aec00156-7cb6-42a8-b033-662ac8d31f98">

#### After

<img width="402" alt="Screenshot 2024-07-27 at 11 44 23 AM" src="https://github.com/user-attachments/assets/8426f632-5429-485a-ac96-4c17640b165d">
