### PR TITLE
fix: mismatch between an iOS dark color

### DIFF
--- a/theme/colors.ts
+++ b/theme/colors.ts
@@ -27,7 +27,7 @@ const IOS_SYSTEM_COLORS = {
     background: 'rgb(0, 0, 0)',
     foreground: 'rgb(255, 255, 255)',
     root: 'rgb(0, 0, 0)',
-    card: 'rgb(28, 28, 30)',
+    card: 'rgb(21, 21, 24)',
     destructive: 'rgb(254, 67, 54)',
     primary: 'rgb(3, 133, 255)',
   },


### PR DESCRIPTION
# Description
This fixes the `card` color mismatch for the iOS dark theme. The javascript color did not match the css variable color.